### PR TITLE
1. 최상단 카드 리스트 뷰 구현

### DIFF
--- a/AppStoreClone.xcodeproj/project.pbxproj
+++ b/AppStoreClone.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		AB47F145286436A0003A0195 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AB47F144286436A0003A0195 /* Preview Assets.xcassets */; };
 		AB47F14E286437B7003A0195 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = AB47F14D286437B7003A0195 /* .swiftlint.yml */; };
 		AB47F15428644356003A0195 /* TopCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB47F15328644356003A0195 /* TopCardView.swift */; };
+		ABAF84582865D8F0000663D1 /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAF84572865D8F0000663D1 /* AppInfo.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -23,6 +24,7 @@
 		AB47F144286436A0003A0195 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		AB47F14D286437B7003A0195 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		AB47F15328644356003A0195 /* TopCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopCardView.swift; sourceTree = "<group>"; };
+		ABAF84572865D8F0000663D1 /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,6 +57,7 @@
 		AB47F13C286436A0003A0195 /* AppStoreClone */ = {
 			isa = PBXGroup;
 			children = (
+				ABAF84562865D8E5000663D1 /* Model */,
 				AB47F152286442AA003A0195 /* View */,
 				AB47F13D286436A0003A0195 /* AppStoreCloneApp.swift */,
 				AB47F13F286436A0003A0195 /* ContentView.swift */,
@@ -79,6 +82,14 @@
 				AB47F15328644356003A0195 /* TopCardView.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		ABAF84562865D8E5000663D1 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				ABAF84572865D8F0000663D1 /* AppInfo.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -175,6 +186,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AB47F15428644356003A0195 /* TopCardView.swift in Sources */,
+				ABAF84582865D8F0000663D1 /* AppInfo.swift in Sources */,
 				AB47F140286436A0003A0195 /* ContentView.swift in Sources */,
 				AB47F13E286436A0003A0195 /* AppStoreCloneApp.swift in Sources */,
 			);

--- a/AppStoreClone.xcodeproj/project.pbxproj
+++ b/AppStoreClone.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		AB47F142286436A0003A0195 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AB47F141286436A0003A0195 /* Assets.xcassets */; };
 		AB47F145286436A0003A0195 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AB47F144286436A0003A0195 /* Preview Assets.xcassets */; };
 		AB47F14E286437B7003A0195 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = AB47F14D286437B7003A0195 /* .swiftlint.yml */; };
+		AB47F15428644356003A0195 /* TopCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB47F15328644356003A0195 /* TopCardView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -21,6 +22,7 @@
 		AB47F141286436A0003A0195 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AB47F144286436A0003A0195 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		AB47F14D286437B7003A0195 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		AB47F15328644356003A0195 /* TopCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopCardView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,6 +55,7 @@
 		AB47F13C286436A0003A0195 /* AppStoreClone */ = {
 			isa = PBXGroup;
 			children = (
+				AB47F152286442AA003A0195 /* View */,
 				AB47F13D286436A0003A0195 /* AppStoreCloneApp.swift */,
 				AB47F13F286436A0003A0195 /* ContentView.swift */,
 				AB47F141286436A0003A0195 /* Assets.xcassets */,
@@ -68,6 +71,14 @@
 				AB47F144286436A0003A0195 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		AB47F152286442AA003A0195 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				AB47F15328644356003A0195 /* TopCardView.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -163,6 +174,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AB47F15428644356003A0195 /* TopCardView.swift in Sources */,
 				AB47F140286436A0003A0195 /* ContentView.swift in Sources */,
 				AB47F13E286436A0003A0195 /* AppStoreCloneApp.swift in Sources */,
 			);

--- a/AppStoreClone.xcodeproj/project.pbxproj
+++ b/AppStoreClone.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AB1680CB2866CDD300C9E498 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680CA2866CDD300C9E498 /* Constants.swift */; };
 		AB47F13E286436A0003A0195 /* AppStoreCloneApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB47F13D286436A0003A0195 /* AppStoreCloneApp.swift */; };
 		AB47F140286436A0003A0195 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB47F13F286436A0003A0195 /* ContentView.swift */; };
 		AB47F142286436A0003A0195 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AB47F141286436A0003A0195 /* Assets.xcassets */; };
@@ -18,6 +19,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		AB1680CA2866CDD300C9E498 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		AB47F13A286436A0003A0195 /* AppStoreClone.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppStoreClone.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB47F13D286436A0003A0195 /* AppStoreCloneApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreCloneApp.swift; sourceTree = "<group>"; };
 		AB47F13F286436A0003A0195 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -91,6 +93,7 @@
 			children = (
 				ABAF84572865D8F0000663D1 /* AppInfo.swift */,
 				ABAF845D286616C4000663D1 /* TopCardAppInfo.swift */,
+				AB1680CA2866CDD300C9E498 /* Constants.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -193,6 +196,7 @@
 				AB47F140286436A0003A0195 /* ContentView.swift in Sources */,
 				ABAF845E286616C4000663D1 /* TopCardAppInfo.swift in Sources */,
 				AB47F13E286436A0003A0195 /* AppStoreCloneApp.swift in Sources */,
+				AB1680CB2866CDD300C9E498 /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AppStoreClone.xcodeproj/project.pbxproj
+++ b/AppStoreClone.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		AB1680CB2866CDD300C9E498 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680CA2866CDD300C9E498 /* Constants.swift */; };
+		AB1680D72866F0BB00C9E498 /* SwiftUIPager in Frameworks */ = {isa = PBXBuildFile; productRef = AB1680D62866F0BB00C9E498 /* SwiftUIPager */; };
+		AB1680D92866F69100C9E498 /* TopCardListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680D82866F69100C9E498 /* TopCardListView.swift */; };
 		AB47F13E286436A0003A0195 /* AppStoreCloneApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB47F13D286436A0003A0195 /* AppStoreCloneApp.swift */; };
 		AB47F140286436A0003A0195 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB47F13F286436A0003A0195 /* ContentView.swift */; };
 		AB47F142286436A0003A0195 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AB47F141286436A0003A0195 /* Assets.xcassets */; };
@@ -20,6 +22,7 @@
 
 /* Begin PBXFileReference section */
 		AB1680CA2866CDD300C9E498 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		AB1680D82866F69100C9E498 /* TopCardListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopCardListView.swift; sourceTree = "<group>"; };
 		AB47F13A286436A0003A0195 /* AppStoreClone.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppStoreClone.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB47F13D286436A0003A0195 /* AppStoreCloneApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreCloneApp.swift; sourceTree = "<group>"; };
 		AB47F13F286436A0003A0195 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -36,6 +39,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AB1680D72866F0BB00C9E498 /* SwiftUIPager in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -84,6 +88,7 @@
 			isa = PBXGroup;
 			children = (
 				AB47F15328644356003A0195 /* TopCardView.swift */,
+				AB1680D82866F69100C9E498 /* TopCardListView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -115,6 +120,9 @@
 			dependencies = (
 			);
 			name = AppStoreClone;
+			packageProductDependencies = (
+				AB1680D62866F0BB00C9E498 /* SwiftUIPager */,
+			);
 			productName = AppStoreClone;
 			productReference = AB47F13A286436A0003A0195 /* AppStoreClone.app */;
 			productType = "com.apple.product-type.application";
@@ -143,6 +151,9 @@
 				Base,
 			);
 			mainGroup = AB47F131286436A0003A0195;
+			packageReferences = (
+				AB1680D52866F0BB00C9E498 /* XCRemoteSwiftPackageReference "SwiftUIPager" */,
+			);
 			productRefGroup = AB47F13B286436A0003A0195 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -197,6 +208,7 @@
 				ABAF845E286616C4000663D1 /* TopCardAppInfo.swift in Sources */,
 				AB47F13E286436A0003A0195 /* AppStoreCloneApp.swift in Sources */,
 				AB1680CB2866CDD300C9E498 /* Constants.swift in Sources */,
+				AB1680D92866F69100C9E498 /* TopCardListView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -397,6 +409,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		AB1680D52866F0BB00C9E498 /* XCRemoteSwiftPackageReference "SwiftUIPager" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/fermoya/SwiftUIPager.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		AB1680D62866F0BB00C9E498 /* SwiftUIPager */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AB1680D52866F0BB00C9E498 /* XCRemoteSwiftPackageReference "SwiftUIPager" */;
+			productName = SwiftUIPager;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = AB47F132286436A0003A0195 /* Project object */;
 }

--- a/AppStoreClone.xcodeproj/project.pbxproj
+++ b/AppStoreClone.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		AB47F14E286437B7003A0195 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = AB47F14D286437B7003A0195 /* .swiftlint.yml */; };
 		AB47F15428644356003A0195 /* TopCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB47F15328644356003A0195 /* TopCardView.swift */; };
 		ABAF84582865D8F0000663D1 /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAF84572865D8F0000663D1 /* AppInfo.swift */; };
+		ABAF845E286616C4000663D1 /* TopCardAppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAF845D286616C4000663D1 /* TopCardAppInfo.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -25,6 +26,7 @@
 		AB47F14D286437B7003A0195 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		AB47F15328644356003A0195 /* TopCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopCardView.swift; sourceTree = "<group>"; };
 		ABAF84572865D8F0000663D1 /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
+		ABAF845D286616C4000663D1 /* TopCardAppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopCardAppInfo.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -88,6 +90,7 @@
 			isa = PBXGroup;
 			children = (
 				ABAF84572865D8F0000663D1 /* AppInfo.swift */,
+				ABAF845D286616C4000663D1 /* TopCardAppInfo.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -188,6 +191,7 @@
 				AB47F15428644356003A0195 /* TopCardView.swift in Sources */,
 				ABAF84582865D8F0000663D1 /* AppInfo.swift in Sources */,
 				AB47F140286436A0003A0195 /* ContentView.swift in Sources */,
+				ABAF845E286616C4000663D1 /* TopCardAppInfo.swift in Sources */,
 				AB47F13E286436A0003A0195 /* AppStoreCloneApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AppStoreClone/Model/AppInfo.swift
+++ b/AppStoreClone/Model/AppInfo.swift
@@ -1,0 +1,46 @@
+//
+//  AppInfo.swift
+//  AppStoreClone
+//
+//  Created by 김남건 on 2022/06/24.
+//
+
+import Foundation
+
+struct TitleReceiver: Codable {
+    let name: String
+}
+
+@MainActor
+class AppInfo: Identifiable, ObservableObject {
+    let id: UUID
+    @Published var title = "Default Title"
+    @Published var subtitle = "Default Subtitle"
+    let isInternalPurchaseExists = Int.random(in: 0...1) == 1
+
+    init(id: UUID) {
+        self.id = id
+    }
+
+    func fetchTitle() async -> String {
+        guard let url = URL(string: "https://api.namefake.com/") else {
+            return "Failed Title"
+        }
+
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            return try JSONDecoder().decode(TitleReceiver.self, from: data).name
+        } catch {
+            print(error)
+            return "Default Title"
+        }
+    }
+
+    func fetchInfo() async {
+        async let title = fetchTitle()
+        async let subtitle = fetchTitle()
+
+        self.title = await title
+        self.subtitle = await subtitle
+    }
+}

--- a/AppStoreClone/Model/AppInfo.swift
+++ b/AppStoreClone/Model/AppInfo.swift
@@ -14,8 +14,8 @@ struct TitleReceiver: Codable {
 @MainActor
 class AppInfo: Identifiable, ObservableObject {
     let id: UUID
-    @Published var title = "Default Title"
-    @Published var subtitle = "Default Subtitle"
+    @Published var name = "Default Name"
+    @Published var subName = "Default SubName"
     let isInternalPurchaseExists = Int.random(in: 0...1) == 1
 
     init(id: UUID) {
@@ -40,7 +40,7 @@ class AppInfo: Identifiable, ObservableObject {
         async let title = fetchTitle()
         async let subtitle = fetchTitle()
 
-        self.title = await title
-        self.subtitle = await subtitle
+        self.name = await title
+        self.subName = await subtitle
     }
 }

--- a/AppStoreClone/Model/Constants.swift
+++ b/AppStoreClone/Model/Constants.swift
@@ -1,0 +1,18 @@
+//
+//  Constants.swift
+//  AppStoreClone
+//
+//  Created by 김남건 on 2022/06/25.
+//
+
+import Foundation
+import UIKit
+
+struct Constants {
+    static var screenWidth: CGFloat {
+        UIScreen.main.bounds.width
+    }
+    static var screenHeight: CGFloat {
+        UIScreen.main.bounds.height
+    }
+}

--- a/AppStoreClone/Model/Constants.swift
+++ b/AppStoreClone/Model/Constants.swift
@@ -15,4 +15,8 @@ struct Constants {
     static var screenHeight: CGFloat {
         UIScreen.main.bounds.height
     }
+
+    static var horizontalMargin: CGFloat {
+        20
+    }
 }

--- a/AppStoreClone/Model/TopCardAppInfo.swift
+++ b/AppStoreClone/Model/TopCardAppInfo.swift
@@ -13,7 +13,9 @@ class TopCardAppInfo: AppInfo {
     @Published var cardSubtitle = "Default Card Subtitle"
 
     override func fetchInfo() async {
-        await super.fetchInfo()
+        Task {
+            await super.fetchInfo()
+        }
         async let cardTitle = fetchTitle()
         async let cardSubtitle = fetchTitle()
 

--- a/AppStoreClone/Model/TopCardAppInfo.swift
+++ b/AppStoreClone/Model/TopCardAppInfo.swift
@@ -9,7 +9,7 @@ import Foundation
 
 @MainActor
 class TopCardAppInfo: AppInfo {
-    @Published var cardTitle = "Default Card Title"
+    @Published var cardLabel = "Default Card Title"
     @Published var cardSubtitle = "Default Card Subtitle"
 
     override func fetchInfo() async {
@@ -17,7 +17,7 @@ class TopCardAppInfo: AppInfo {
         async let cardTitle = fetchTitle()
         async let cardSubtitle = fetchTitle()
 
-        self.cardTitle = await cardTitle
+        self.cardLabel = await cardTitle
         self.cardSubtitle = await cardSubtitle
     }
 }

--- a/AppStoreClone/Model/TopCardAppInfo.swift
+++ b/AppStoreClone/Model/TopCardAppInfo.swift
@@ -1,0 +1,23 @@
+//
+//  TopCardAppInfo.swift
+//  AppStoreClone
+//
+//  Created by 김남건 on 2022/06/25.
+//
+
+import Foundation
+
+@MainActor
+class TopCardAppInfo: AppInfo {
+    @Published var cardTitle = "Default Card Title"
+    @Published var cardSubtitle = "Default Card Subtitle"
+
+    override func fetchInfo() async {
+        await super.fetchInfo()
+        async let cardTitle = fetchTitle()
+        async let cardSubtitle = fetchTitle()
+
+        self.cardTitle = await cardTitle
+        self.cardSubtitle = await cardSubtitle
+    }
+}

--- a/AppStoreClone/View/TopCardListView.swift
+++ b/AppStoreClone/View/TopCardListView.swift
@@ -1,0 +1,43 @@
+//
+//  TopCardListView.swift
+//  AppStoreClone
+//
+//  Created by 김남건 on 2022/06/25.
+//
+
+import SwiftUI
+import SwiftUIPager
+
+struct TopCardListView: View {
+    @StateObject var page: Page = .first()
+    var items = Array(0..<10).map { _ in UUID() }
+
+    var pagerHeight: CGFloat {
+        Constants.screenHeight * (224 / 844) + 72
+    }
+
+    var spacing: CGFloat {
+        Constants.screenHeight * (28.5 / 844)
+    }
+
+    var body: some View {
+        VStack(spacing: spacing) {
+            Pager(page: page,
+                  data: items,
+                  id: \.self,
+                  content: { TopCardView(appId: $0)
+             })
+            .preferredItemSize(CGSize(width: 350, height: pagerHeight))
+            .itemSpacing(10)
+            .frame(height: pagerHeight)
+            Divider()
+                .padding(.horizontal, 20)
+        }
+     }
+}
+
+struct TopCardListView_Previews: PreviewProvider {
+    static var previews: some View {
+        TopCardListView().preferredColorScheme(.dark)
+    }
+}

--- a/AppStoreClone/View/TopCardListView.swift
+++ b/AppStoreClone/View/TopCardListView.swift
@@ -28,10 +28,10 @@ struct TopCardListView: View {
                   content: { TopCardView(appId: $0)
              })
             .preferredItemSize(CGSize(width: 350, height: pagerHeight))
-            .itemSpacing(10)
+            .itemSpacing(Constants.horizontalMargin / 2)
             .frame(height: pagerHeight)
             Divider()
-                .padding(.horizontal, 20)
+                .padding(.horizontal, Constants.horizontalMargin)
         }
      }
 }

--- a/AppStoreClone/View/TopCardView.swift
+++ b/AppStoreClone/View/TopCardView.swift
@@ -65,7 +65,6 @@ struct TopCardView: View {
                                 }
                                 .frame(width: 74, height: 29)
                             }
-                            
                             if topCardAppInfo.isInternalPurchaseExists {
                                 Text("앱 내 구입")
                                     .font(.system(size: 9))

--- a/AppStoreClone/View/TopCardView.swift
+++ b/AppStoreClone/View/TopCardView.swift
@@ -14,7 +14,7 @@ struct TopCardView: View {
         VStack {
             HStack {
                 VStack(alignment: .leading) {
-                    Text(topCardAppInfo.cardTitle)
+                    Text(topCardAppInfo.cardLabel)
                         .foregroundColor(.blue)
                         .font(.caption)
                     Text(topCardAppInfo.name)

--- a/AppStoreClone/View/TopCardView.swift
+++ b/AppStoreClone/View/TopCardView.swift
@@ -93,6 +93,6 @@ struct TopCardView_Previews: PreviewProvider {
     static var previews: some View {
         TopCardView(appId: UUID())
             .preferredColorScheme(.dark)
-            .padding(.horizontal, 16)
+            .padding(.horizontal, Constants.horizontalMargin)
     }
 }

--- a/AppStoreClone/View/TopCardView.swift
+++ b/AppStoreClone/View/TopCardView.swift
@@ -1,0 +1,87 @@
+//
+//  TopCardView.swift
+//  AppStoreClone
+//
+//  Created by 김남건 on 2022/06/23.
+//
+
+import SwiftUI
+
+struct TopCardView: View {
+    var body: some View {
+        VStack {
+            HStack {
+                VStack(alignment: .leading) {
+                    Text("현재 진행 중")
+                        .foregroundColor(.blue)
+                        .font(.caption)
+                    Text("리그 오브 레전드 : 와일드 리프트")
+                        .font(.title2)
+                    Text("파이크와 노틸러스 등장!")
+                        .foregroundColor(Color(.systemGray))
+                        .font(.title3)
+                }
+                Spacer()
+            }
+            ZStack {
+                AsyncImage(url: URL(string: "https://source.unsplash.com/random")) { image in
+                    image.resizable()
+                } placeholder: {
+                    ProgressView()
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+                VStack {
+                    Spacer()
+                    HStack {
+                        AsyncImage(url: URL(string: "https://source.unsplash.com/random")) { image in
+                            image.resizable()
+                        } placeholder: {
+                            ProgressView()
+                        }
+                        .clipShape(RoundedRectangle(cornerRadius: 5))
+                        .frame(width: 37, height: 37)
+                        VStack(alignment: .leading) {
+                            Text("리그 오브 레전드 : 와일드 리프트")
+                                .font(.caption)
+                                .foregroundColor(.white)
+                            Text("5:5 MOBA 전투를 위한 팀을 구성하세요.")
+                                .font(.caption2)
+                                .foregroundColor(Color(.lightGray))
+                        }
+                        .padding(.bottom, 2)
+                        Spacer()
+                        VStack(spacing: 5) {
+                            Button {
+                            } label: {
+                                ZStack {
+                                    RoundedRectangle(cornerRadius: 15)
+                                        .foregroundColor(.white.opacity(0.5))
+                                    Text("받기")
+                                        .font(.system(size: 14))
+                                        .fontWeight(.semibold)
+                                        .foregroundColor(.white)
+                                }
+                                .frame(width: 74, height: 29)
+                            }
+                            Text("앱 내 구입")
+                                .font(.system(size: 9))
+                                .foregroundColor(.white)
+                        }
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.bottom, 9)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: UIScreen.main.bounds.height * (224 / 844))
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+struct TopCardView_Previews: PreviewProvider {
+    static var previews: some View {
+        TopCardView()
+            .preferredColorScheme(.dark)
+            .padding(.horizontal, 16)
+    }
+}

--- a/AppStoreClone/View/TopCardView.swift
+++ b/AppStoreClone/View/TopCardView.swift
@@ -8,16 +8,18 @@
 import SwiftUI
 
 struct TopCardView: View {
+    @StateObject private var topCardAppInfo = TopCardAppInfo(id: UUID())
+
     var body: some View {
         VStack {
             HStack {
                 VStack(alignment: .leading) {
-                    Text("현재 진행 중")
+                    Text(topCardAppInfo.cardTitle)
                         .foregroundColor(.blue)
                         .font(.caption)
-                    Text("리그 오브 레전드 : 와일드 리프트")
+                    Text(topCardAppInfo.name)
                         .font(.title2)
-                    Text("파이크와 노틸러스 등장!")
+                    Text(topCardAppInfo.cardSubtitle)
                         .foregroundColor(Color(.systemGray))
                         .font(.title3)
                 }
@@ -41,10 +43,10 @@ struct TopCardView: View {
                         .clipShape(RoundedRectangle(cornerRadius: 5))
                         .frame(width: 37, height: 37)
                         VStack(alignment: .leading) {
-                            Text("리그 오브 레전드 : 와일드 리프트")
+                            Text(topCardAppInfo.name)
                                 .font(.caption)
                                 .foregroundColor(.white)
-                            Text("5:5 MOBA 전투를 위한 팀을 구성하세요.")
+                            Text(topCardAppInfo.subName)
                                 .font(.caption2)
                                 .foregroundColor(Color(.lightGray))
                         }
@@ -75,6 +77,9 @@ struct TopCardView: View {
             .frame(maxWidth: .infinity, maxHeight: UIScreen.main.bounds.height * (224 / 844))
         }
         .frame(maxWidth: .infinity)
+        .task {
+            await topCardAppInfo.fetchInfo()
+        }
     }
 }
 

--- a/AppStoreClone/View/TopCardView.swift
+++ b/AppStoreClone/View/TopCardView.swift
@@ -33,7 +33,12 @@ struct TopCardView: View {
                 AsyncImage(url: URL(string: "https://source.unsplash.com/random")) { image in
                     image.resizable()
                 } placeholder: {
-                    ProgressView()
+                    VStack(spacing: 5) {
+                        ProgressView()
+                        Text("앱 정보 로드 중")
+                            .font(.caption)
+                            .foregroundColor(Color(.lightGray))
+                    }
                 }
                 .clipShape(RoundedRectangle(cornerRadius: 5))
                 VStack {

--- a/AppStoreClone/View/TopCardView.swift
+++ b/AppStoreClone/View/TopCardView.swift
@@ -8,7 +8,11 @@
 import SwiftUI
 
 struct TopCardView: View {
-    @StateObject private var topCardAppInfo = TopCardAppInfo(id: UUID())
+    @StateObject private var topCardAppInfo: TopCardAppInfo
+
+    init(appId: UUID) {
+        _topCardAppInfo = StateObject<TopCardAppInfo>(wrappedValue: TopCardAppInfo(id: appId))
+    }
 
     var body: some View {
         VStack {
@@ -87,7 +91,7 @@ struct TopCardView: View {
 
 struct TopCardView_Previews: PreviewProvider {
     static var previews: some View {
-        TopCardView()
+        TopCardView(appId: UUID())
             .preferredColorScheme(.dark)
             .padding(.horizontal, 16)
     }

--- a/AppStoreClone/View/TopCardView.swift
+++ b/AppStoreClone/View/TopCardView.swift
@@ -65,18 +65,21 @@ struct TopCardView: View {
                                 }
                                 .frame(width: 74, height: 29)
                             }
-                            Text("앱 내 구입")
-                                .font(.system(size: 9))
-                                .foregroundColor(.white)
+                            
+                            if topCardAppInfo.isInternalPurchaseExists {
+                                Text("앱 내 구입")
+                                    .font(.system(size: 9))
+                                    .foregroundColor(.white)
+                            }
                         }
                     }
                     .padding(.horizontal, 14)
                     .padding(.bottom, 9)
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: UIScreen.main.bounds.height * (224 / 844))
+            .frame(height: Constants.screenHeight * (224 / 844))
         }
-        .frame(maxWidth: .infinity)
+        .frame(width: Constants.screenWidth * (350 / 390))
         .task {
             await topCardAppInfo.fetchInfo()
         }


### PR DESCRIPTION
## 세부사항
* Constants: 화면 width, height, horizontal margin 등의 값 정의
* AppInfo: 앱 id, 앱 이름, 부제, 내부 구매 여부 저장하는 클래스, fetchInfo() 통해 비동기적으로 앱 정보 받아옴
* TopCardAppInfo: AppInfo 상속받고, TopCardView에 사용될 label와 subTitle을 추가로 저장, fetchInfo() 통해 비동기적으로 앱 정보 받아옴
* TopCardView: appId를 받으면 그걸 가지고 앱 정보를 fetch받아 보여주는 카드 뷰
* TopCardListView: 게임, 앱 탭에 사용할 최상단 카드 리스트 뷰, 10개의 TopCardView로 구성

## 기타 질문 및 특이사항
* TopCardListView 구현 위해 SPM 사용하여 SwiftUIPager를 import

## 체크리스트
- [x] SwiftLint에서 error나 warning이 발생하지 않는 것을 확인하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋된 것을 확인하였습니다.