### PR TITLE
2. 한 column 당 앱을 3개씩 보여주는 paging view 구현

### DIFF
--- a/AppStoreClone.xcodeproj/project.pbxproj
+++ b/AppStoreClone.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		AB1680D92866F69100C9E498 /* TopCardListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680D82866F69100C9E498 /* TopCardListView.swift */; };
 		AB1680DF28672B1000C9E498 /* DownloadButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680DE28672B1000C9E498 /* DownloadButton.swift */; };
 		AB1680E128672DF200C9E498 /* SmallAppInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680E028672DF200C9E498 /* SmallAppInfoView.swift */; };
+		AB1680E32867336100C9E498 /* RandomImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680E22867336100C9E498 /* RandomImage.swift */; };
 		AB47F13E286436A0003A0195 /* AppStoreCloneApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB47F13D286436A0003A0195 /* AppStoreCloneApp.swift */; };
 		AB47F140286436A0003A0195 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB47F13F286436A0003A0195 /* ContentView.swift */; };
 		AB47F142286436A0003A0195 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AB47F141286436A0003A0195 /* Assets.xcassets */; };
@@ -27,6 +28,7 @@
 		AB1680D82866F69100C9E498 /* TopCardListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopCardListView.swift; sourceTree = "<group>"; };
 		AB1680DE28672B1000C9E498 /* DownloadButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadButton.swift; sourceTree = "<group>"; };
 		AB1680E028672DF200C9E498 /* SmallAppInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallAppInfoView.swift; sourceTree = "<group>"; };
+		AB1680E22867336100C9E498 /* RandomImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomImage.swift; sourceTree = "<group>"; };
 		AB47F13A286436A0003A0195 /* AppStoreClone.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppStoreClone.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB47F13D286436A0003A0195 /* AppStoreCloneApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreCloneApp.swift; sourceTree = "<group>"; };
 		AB47F13F286436A0003A0195 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 				AB1680D82866F69100C9E498 /* TopCardListView.swift */,
 				AB1680DE28672B1000C9E498 /* DownloadButton.swift */,
 				AB1680E028672DF200C9E498 /* SmallAppInfoView.swift */,
+				AB1680E22867336100C9E498 /* RandomImage.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -212,6 +215,7 @@
 				AB47F15428644356003A0195 /* TopCardView.swift in Sources */,
 				ABAF84582865D8F0000663D1 /* AppInfo.swift in Sources */,
 				AB47F140286436A0003A0195 /* ContentView.swift in Sources */,
+				AB1680E32867336100C9E498 /* RandomImage.swift in Sources */,
 				AB1680DF28672B1000C9E498 /* DownloadButton.swift in Sources */,
 				ABAF845E286616C4000663D1 /* TopCardAppInfo.swift in Sources */,
 				AB47F13E286436A0003A0195 /* AppStoreCloneApp.swift in Sources */,

--- a/AppStoreClone.xcodeproj/project.pbxproj
+++ b/AppStoreClone.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		AB1680D72866F0BB00C9E498 /* SwiftUIPager in Frameworks */ = {isa = PBXBuildFile; productRef = AB1680D62866F0BB00C9E498 /* SwiftUIPager */; };
 		AB1680D92866F69100C9E498 /* TopCardListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680D82866F69100C9E498 /* TopCardListView.swift */; };
 		AB1680DF28672B1000C9E498 /* DownloadButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680DE28672B1000C9E498 /* DownloadButton.swift */; };
+		AB1680E128672DF200C9E498 /* SmallAppInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680E028672DF200C9E498 /* SmallAppInfoView.swift */; };
 		AB47F13E286436A0003A0195 /* AppStoreCloneApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB47F13D286436A0003A0195 /* AppStoreCloneApp.swift */; };
 		AB47F140286436A0003A0195 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB47F13F286436A0003A0195 /* ContentView.swift */; };
 		AB47F142286436A0003A0195 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AB47F141286436A0003A0195 /* Assets.xcassets */; };
@@ -25,6 +26,7 @@
 		AB1680CA2866CDD300C9E498 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		AB1680D82866F69100C9E498 /* TopCardListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopCardListView.swift; sourceTree = "<group>"; };
 		AB1680DE28672B1000C9E498 /* DownloadButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadButton.swift; sourceTree = "<group>"; };
+		AB1680E028672DF200C9E498 /* SmallAppInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallAppInfoView.swift; sourceTree = "<group>"; };
 		AB47F13A286436A0003A0195 /* AppStoreClone.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppStoreClone.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB47F13D286436A0003A0195 /* AppStoreCloneApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreCloneApp.swift; sourceTree = "<group>"; };
 		AB47F13F286436A0003A0195 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -92,6 +94,7 @@
 				AB47F15328644356003A0195 /* TopCardView.swift */,
 				AB1680D82866F69100C9E498 /* TopCardListView.swift */,
 				AB1680DE28672B1000C9E498 /* DownloadButton.swift */,
+				AB1680E028672DF200C9E498 /* SmallAppInfoView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -205,6 +208,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AB1680E128672DF200C9E498 /* SmallAppInfoView.swift in Sources */,
 				AB47F15428644356003A0195 /* TopCardView.swift in Sources */,
 				ABAF84582865D8F0000663D1 /* AppInfo.swift in Sources */,
 				AB47F140286436A0003A0195 /* ContentView.swift in Sources */,

--- a/AppStoreClone.xcodeproj/project.pbxproj
+++ b/AppStoreClone.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		AB1680DF28672B1000C9E498 /* DownloadButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680DE28672B1000C9E498 /* DownloadButton.swift */; };
 		AB1680E128672DF200C9E498 /* SmallAppInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680E028672DF200C9E498 /* SmallAppInfoView.swift */; };
 		AB1680E32867336100C9E498 /* RandomImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680E22867336100C9E498 /* RandomImage.swift */; };
+		AB1680F1286761D700C9E498 /* SmallAppInfoColumnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680F0286761D700C9E498 /* SmallAppInfoColumnView.swift */; };
 		AB47F13E286436A0003A0195 /* AppStoreCloneApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB47F13D286436A0003A0195 /* AppStoreCloneApp.swift */; };
 		AB47F140286436A0003A0195 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB47F13F286436A0003A0195 /* ContentView.swift */; };
 		AB47F142286436A0003A0195 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AB47F141286436A0003A0195 /* Assets.xcassets */; };
@@ -29,6 +30,7 @@
 		AB1680DE28672B1000C9E498 /* DownloadButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadButton.swift; sourceTree = "<group>"; };
 		AB1680E028672DF200C9E498 /* SmallAppInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallAppInfoView.swift; sourceTree = "<group>"; };
 		AB1680E22867336100C9E498 /* RandomImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomImage.swift; sourceTree = "<group>"; };
+		AB1680F0286761D700C9E498 /* SmallAppInfoColumnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallAppInfoColumnView.swift; sourceTree = "<group>"; };
 		AB47F13A286436A0003A0195 /* AppStoreClone.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppStoreClone.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB47F13D286436A0003A0195 /* AppStoreCloneApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreCloneApp.swift; sourceTree = "<group>"; };
 		AB47F13F286436A0003A0195 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -98,6 +100,7 @@
 				AB1680DE28672B1000C9E498 /* DownloadButton.swift */,
 				AB1680E028672DF200C9E498 /* SmallAppInfoView.swift */,
 				AB1680E22867336100C9E498 /* RandomImage.swift */,
+				AB1680F0286761D700C9E498 /* SmallAppInfoColumnView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -214,6 +217,7 @@
 				AB1680E128672DF200C9E498 /* SmallAppInfoView.swift in Sources */,
 				AB47F15428644356003A0195 /* TopCardView.swift in Sources */,
 				ABAF84582865D8F0000663D1 /* AppInfo.swift in Sources */,
+				AB1680F1286761D700C9E498 /* SmallAppInfoColumnView.swift in Sources */,
 				AB47F140286436A0003A0195 /* ContentView.swift in Sources */,
 				AB1680E32867336100C9E498 /* RandomImage.swift in Sources */,
 				AB1680DF28672B1000C9E498 /* DownloadButton.swift in Sources */,

--- a/AppStoreClone.xcodeproj/project.pbxproj
+++ b/AppStoreClone.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		AB1680CB2866CDD300C9E498 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680CA2866CDD300C9E498 /* Constants.swift */; };
 		AB1680D72866F0BB00C9E498 /* SwiftUIPager in Frameworks */ = {isa = PBXBuildFile; productRef = AB1680D62866F0BB00C9E498 /* SwiftUIPager */; };
 		AB1680D92866F69100C9E498 /* TopCardListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680D82866F69100C9E498 /* TopCardListView.swift */; };
+		AB1680DF28672B1000C9E498 /* DownloadButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680DE28672B1000C9E498 /* DownloadButton.swift */; };
 		AB47F13E286436A0003A0195 /* AppStoreCloneApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB47F13D286436A0003A0195 /* AppStoreCloneApp.swift */; };
 		AB47F140286436A0003A0195 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB47F13F286436A0003A0195 /* ContentView.swift */; };
 		AB47F142286436A0003A0195 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AB47F141286436A0003A0195 /* Assets.xcassets */; };
@@ -23,6 +24,7 @@
 /* Begin PBXFileReference section */
 		AB1680CA2866CDD300C9E498 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		AB1680D82866F69100C9E498 /* TopCardListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopCardListView.swift; sourceTree = "<group>"; };
+		AB1680DE28672B1000C9E498 /* DownloadButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadButton.swift; sourceTree = "<group>"; };
 		AB47F13A286436A0003A0195 /* AppStoreClone.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppStoreClone.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB47F13D286436A0003A0195 /* AppStoreCloneApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreCloneApp.swift; sourceTree = "<group>"; };
 		AB47F13F286436A0003A0195 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -89,6 +91,7 @@
 			children = (
 				AB47F15328644356003A0195 /* TopCardView.swift */,
 				AB1680D82866F69100C9E498 /* TopCardListView.swift */,
+				AB1680DE28672B1000C9E498 /* DownloadButton.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -205,6 +208,7 @@
 				AB47F15428644356003A0195 /* TopCardView.swift in Sources */,
 				ABAF84582865D8F0000663D1 /* AppInfo.swift in Sources */,
 				AB47F140286436A0003A0195 /* ContentView.swift in Sources */,
+				AB1680DF28672B1000C9E498 /* DownloadButton.swift in Sources */,
 				ABAF845E286616C4000663D1 /* TopCardAppInfo.swift in Sources */,
 				AB47F13E286436A0003A0195 /* AppStoreCloneApp.swift in Sources */,
 				AB1680CB2866CDD300C9E498 /* Constants.swift in Sources */,

--- a/AppStoreClone.xcodeproj/project.pbxproj
+++ b/AppStoreClone.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		AB1680E128672DF200C9E498 /* SmallAppInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680E028672DF200C9E498 /* SmallAppInfoView.swift */; };
 		AB1680E32867336100C9E498 /* RandomImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680E22867336100C9E498 /* RandomImage.swift */; };
 		AB1680F1286761D700C9E498 /* SmallAppInfoColumnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680F0286761D700C9E498 /* SmallAppInfoColumnView.swift */; };
+		AB1680F3286763EE00C9E498 /* SmallAppInfoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680F2286763EE00C9E498 /* SmallAppInfoListView.swift */; };
+		AB1680F52867698C00C9E498 /* AppIdWithIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1680F42867698C00C9E498 /* AppIdWithIndex.swift */; };
 		AB47F13E286436A0003A0195 /* AppStoreCloneApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB47F13D286436A0003A0195 /* AppStoreCloneApp.swift */; };
 		AB47F140286436A0003A0195 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB47F13F286436A0003A0195 /* ContentView.swift */; };
 		AB47F142286436A0003A0195 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AB47F141286436A0003A0195 /* Assets.xcassets */; };
@@ -31,6 +33,8 @@
 		AB1680E028672DF200C9E498 /* SmallAppInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallAppInfoView.swift; sourceTree = "<group>"; };
 		AB1680E22867336100C9E498 /* RandomImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomImage.swift; sourceTree = "<group>"; };
 		AB1680F0286761D700C9E498 /* SmallAppInfoColumnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallAppInfoColumnView.swift; sourceTree = "<group>"; };
+		AB1680F2286763EE00C9E498 /* SmallAppInfoListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallAppInfoListView.swift; sourceTree = "<group>"; };
+		AB1680F42867698C00C9E498 /* AppIdWithIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIdWithIndex.swift; sourceTree = "<group>"; };
 		AB47F13A286436A0003A0195 /* AppStoreClone.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppStoreClone.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB47F13D286436A0003A0195 /* AppStoreCloneApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreCloneApp.swift; sourceTree = "<group>"; };
 		AB47F13F286436A0003A0195 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -101,6 +105,7 @@
 				AB1680E028672DF200C9E498 /* SmallAppInfoView.swift */,
 				AB1680E22867336100C9E498 /* RandomImage.swift */,
 				AB1680F0286761D700C9E498 /* SmallAppInfoColumnView.swift */,
+				AB1680F2286763EE00C9E498 /* SmallAppInfoListView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -111,6 +116,7 @@
 				ABAF84572865D8F0000663D1 /* AppInfo.swift */,
 				ABAF845D286616C4000663D1 /* TopCardAppInfo.swift */,
 				AB1680CA2866CDD300C9E498 /* Constants.swift */,
+				AB1680F42867698C00C9E498 /* AppIdWithIndex.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -216,6 +222,7 @@
 			files = (
 				AB1680E128672DF200C9E498 /* SmallAppInfoView.swift in Sources */,
 				AB47F15428644356003A0195 /* TopCardView.swift in Sources */,
+				AB1680F3286763EE00C9E498 /* SmallAppInfoListView.swift in Sources */,
 				ABAF84582865D8F0000663D1 /* AppInfo.swift in Sources */,
 				AB1680F1286761D700C9E498 /* SmallAppInfoColumnView.swift in Sources */,
 				AB47F140286436A0003A0195 /* ContentView.swift in Sources */,
@@ -223,6 +230,7 @@
 				AB1680DF28672B1000C9E498 /* DownloadButton.swift in Sources */,
 				ABAF845E286616C4000663D1 /* TopCardAppInfo.swift in Sources */,
 				AB47F13E286436A0003A0195 /* AppStoreCloneApp.swift in Sources */,
+				AB1680F52867698C00C9E498 /* AppIdWithIndex.swift in Sources */,
 				AB1680CB2866CDD300C9E498 /* Constants.swift in Sources */,
 				AB1680D92866F69100C9E498 /* TopCardListView.swift in Sources */,
 			);

--- a/AppStoreClone/Model/AppIdWithIndex.swift
+++ b/AppStoreClone/Model/AppIdWithIndex.swift
@@ -1,0 +1,13 @@
+//
+//  AppIdWithIndex.swift
+//  AppStoreClone
+//
+//  Created by 김남건 on 2022/06/26.
+//
+
+import Foundation
+
+struct AppIdWithIndex: Equatable, Hashable {
+    let id: UUID
+    let index: Int
+}

--- a/AppStoreClone/Model/AppInfo.swift
+++ b/AppStoreClone/Model/AppInfo.swift
@@ -16,7 +16,7 @@ class AppInfo: Identifiable, ObservableObject {
     let id: UUID
     @Published var name = "Default Name"
     @Published var subName = "Default SubName"
-    let isInternalPurchaseExists = Int.random(in: 0...1) == 1
+    let hasInternalPurchase = Int.random(in: 0...1) == 1
 
     init(id: UUID) {
         self.id = id

--- a/AppStoreClone/View/DownloadButton.swift
+++ b/AppStoreClone/View/DownloadButton.swift
@@ -1,0 +1,41 @@
+//
+//  DownloadButton.swift
+//  AppStoreClone
+//
+//  Created by 김남건 on 2022/06/25.
+//
+
+import SwiftUI
+
+struct DownloadButton: View {
+    let hasPurchase: Bool
+
+    var body: some View {
+        VStack(spacing: 5) {
+            Button {
+            } label: {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 15)
+                        .foregroundColor(.white.opacity(0.5))
+                    Text("받기")
+                        .font(.system(size: 14))
+                        .fontWeight(.semibold)
+                        .foregroundColor(.white)
+                }
+                .frame(width: 74, height: 29)
+            }
+            if hasPurchase {
+                Text("앱 내 구입")
+                    .font(.system(size: 9))
+                    .foregroundColor(.white)
+            }
+        }
+    }
+}
+
+struct DownloadButton_Previews: PreviewProvider {
+    static var previews: some View {
+        DownloadButton(hasPurchase: true)
+            .preferredColorScheme(.dark)
+    }
+}

--- a/AppStoreClone/View/DownloadButton.swift
+++ b/AppStoreClone/View/DownloadButton.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct DownloadButton: View {
     let hasPurchase: Bool
+    let isBright: Bool
 
     var body: some View {
         VStack(spacing: 5) {
@@ -16,18 +17,18 @@ struct DownloadButton: View {
             } label: {
                 ZStack {
                     RoundedRectangle(cornerRadius: 15)
-                        .foregroundColor(.white.opacity(0.5))
+                        .foregroundColor((isBright ? Color.white : .gray).opacity(0.5))
                     Text("받기")
                         .font(.system(size: 14))
                         .fontWeight(.semibold)
-                        .foregroundColor(.white)
+                        .foregroundColor(isBright ? .white : .blue)
                 }
                 .frame(width: 74, height: 29)
             }
             if hasPurchase {
                 Text("앱 내 구입")
                     .font(.system(size: 9))
-                    .foregroundColor(.white)
+                    .foregroundColor(isBright ? .white : .gray)
             }
         }
     }
@@ -35,7 +36,7 @@ struct DownloadButton: View {
 
 struct DownloadButton_Previews: PreviewProvider {
     static var previews: some View {
-        DownloadButton(hasPurchase: true)
+        DownloadButton(hasPurchase: true, isBright: false)
             .preferredColorScheme(.dark)
     }
 }

--- a/AppStoreClone/View/RandomImage.swift
+++ b/AppStoreClone/View/RandomImage.swift
@@ -1,0 +1,29 @@
+//
+//  RandomImage.swift
+//  AppStoreClone
+//
+//  Created by 김남건 on 2022/06/25.
+//
+
+import SwiftUI
+
+struct RandomImage: View {
+    let cornerRadius: CGFloat
+
+    var body: some View {
+        AsyncImage(url: URL(string: "https://source.unsplash.com/random")) { image in
+            image.resizable()
+        } placeholder: {
+            ProgressView()
+        }
+        .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+    }
+}
+
+struct RandomImage_Previews: PreviewProvider {
+    static var previews: some View {
+        RandomImage(cornerRadius: 12)
+            .frame(width: 62, height: 62)
+            .preferredColorScheme(.dark)
+    }
+}

--- a/AppStoreClone/View/SmallAppInfoColumnView.swift
+++ b/AppStoreClone/View/SmallAppInfoColumnView.swift
@@ -9,13 +9,14 @@ import SwiftUI
 
 struct SmallAppInfoColumnView: View {
     let ranked: Bool
-    let appIdRankTuples: [(UUID, Int)]
+    let appIdRankTuples: [AppIdWithIndex]
 
     var body: some View {
         VStack(spacing: 5) {
-            ForEach(appIdRankTuples, id: \.0) { id, index in
-                SmallAppInfoView(appId: id, index: index, ranked: ranked)
+            ForEach(appIdRankTuples, id: \.id) { appIdWithIndex in
+                SmallAppInfoView(appId: appIdWithIndex.id, index: appIdWithIndex.index, ranked: ranked)
             }
+            Spacer(minLength: 0)
         }
     }
 }
@@ -23,9 +24,9 @@ struct SmallAppInfoColumnView: View {
 struct SmallAppInfoColumnView_Previews: PreviewProvider {
     static var previews: some View {
         SmallAppInfoColumnView(ranked: true, appIdRankTuples: [
-            (UUID(), 1),
-            (UUID(), 2),
-            (UUID(), 3)
+            AppIdWithIndex(id: UUID(), index: 1),
+            AppIdWithIndex(id: UUID(), index: 2),
+            AppIdWithIndex(id: UUID(), index: 3)
         ]).preferredColorScheme(.dark)
     }
 }

--- a/AppStoreClone/View/SmallAppInfoColumnView.swift
+++ b/AppStoreClone/View/SmallAppInfoColumnView.swift
@@ -1,0 +1,31 @@
+//
+//  SmallAppInfoColumnView.swift
+//  AppStoreClone
+//
+//  Created by 김남건 on 2022/06/26.
+//
+
+import SwiftUI
+
+struct SmallAppInfoColumnView: View {
+    let ranked: Bool
+    let appIdRankTuples: [(UUID, Int)]
+
+    var body: some View {
+        VStack(spacing: 5) {
+            ForEach(appIdRankTuples, id: \.0) { id, index in
+                SmallAppInfoView(appId: id, index: index, ranked: ranked)
+            }
+        }
+    }
+}
+
+struct SmallAppInfoColumnView_Previews: PreviewProvider {
+    static var previews: some View {
+        SmallAppInfoColumnView(ranked: true, appIdRankTuples: [
+            (UUID(), 1),
+            (UUID(), 2),
+            (UUID(), 3)
+        ]).preferredColorScheme(.dark)
+    }
+}

--- a/AppStoreClone/View/SmallAppInfoListView.swift
+++ b/AppStoreClone/View/SmallAppInfoListView.swift
@@ -1,0 +1,56 @@
+//
+//  SmallAppInfoListView.swift
+//  AppStoreClone
+//
+//  Created by 김남건 on 2022/06/26.
+//
+
+import Combine
+import SwiftUI
+import SwiftUIPager
+
+struct SmallAppInfoListView: View {
+    let appsCount: Int
+    let ranked: Bool
+    let appTupleColumns: [[AppIdWithIndex]]
+    @StateObject var page: Page = .first()
+
+    init(appsCount: Int, ranked: Bool) {
+        self.appsCount = appsCount
+        self.ranked = ranked
+
+        var subscriptions = Set<AnyCancellable>()
+        var columns = [[AppIdWithIndex]]()
+
+        Array(1...appsCount).map { index in
+            AppIdWithIndex(id: UUID(), index: index)
+        }
+        .publisher
+        .collect(3)
+        .sink {
+            columns.append($0)
+        }
+        .store(in: &subscriptions)
+
+        appTupleColumns = columns
+    }
+
+    var body: some View {
+        Pager(page: page,
+              data: appTupleColumns,
+              id: \.self,
+              content: { column in
+                SmallAppInfoColumnView(ranked: ranked, appIdRankTuples: column)
+            }
+        )
+        .preferredItemSize(CGSize(width: Constants.screenWidth - 2 * Constants.horizontalMargin, height: 218))
+        .itemSpacing(Constants.horizontalMargin / 2)
+        .frame(height: 218)
+    }
+}
+
+struct SmallAppInfoListView_Previews: PreviewProvider {
+    static var previews: some View {
+        SmallAppInfoListView(appsCount: 20, ranked: true).preferredColorScheme(.dark)
+    }
+}

--- a/AppStoreClone/View/SmallAppInfoView.swift
+++ b/AppStoreClone/View/SmallAppInfoView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SmallAppInfoView: View {
     @StateObject private var appInfo: AppInfo
     let index: Int
-    let ranked: Bool
+    let ranked: Bool // ranked가 true인 경우 index를 순위로 사용
 
     init(appId: UUID, index: Int, ranked: Bool) {
         _appInfo = StateObject(wrappedValue: AppInfo(id: appId))

--- a/AppStoreClone/View/SmallAppInfoView.swift
+++ b/AppStoreClone/View/SmallAppInfoView.swift
@@ -1,0 +1,41 @@
+//
+//  SmallAppInfoView.swift
+//  AppStoreClone
+//
+//  Created by 김남건 on 2022/06/25.
+//
+
+import SwiftUI
+
+struct SmallAppInfoView: View {
+    var body: some View {
+        HStack {
+            AsyncImage(url: URL(string: "https://source.unsplash.com/random")) { image in
+                image.resizable()
+            } placeholder: {
+                ProgressView()
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .frame(width: 62, height: 62)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("리그 오브 레전드: 와일드 리프트")
+                    .font(.subheadline)
+                Text("5:5 MOBA 전투를 위한\n팀을 구성하세요")
+                    .font(.caption)
+                    .foregroundColor(Color(.lightGray))
+            }
+            
+            Spacer()
+            
+            DownloadButton(hasPurchase: false)
+        }
+        .frame(width: Constants.screenWidth - Constants.horizontalMargin * 2)
+    }
+}
+
+struct SmallAppInfoView_Previews: PreviewProvider {
+    static var previews: some View {
+        SmallAppInfoView().preferredColorScheme(.dark)
+    }
+}

--- a/AppStoreClone/View/SmallAppInfoView.swift
+++ b/AppStoreClone/View/SmallAppInfoView.swift
@@ -46,7 +46,7 @@ struct SmallAppInfoView: View {
 
                 Spacer(minLength: 0)
 
-                DownloadButton(hasPurchase: appInfo.hasInternalPurchase)
+                DownloadButton(hasPurchase: appInfo.hasInternalPurchase, isBright: false)
             }
 
             if !index.isMultiple(of: 3) {

--- a/AppStoreClone/View/SmallAppInfoView.swift
+++ b/AppStoreClone/View/SmallAppInfoView.swift
@@ -9,25 +9,38 @@ import SwiftUI
 
 struct SmallAppInfoView: View {
     @StateObject private var appInfo: AppInfo
+    let rank: Int?
 
-    init(appId: UUID) {
+    init(appId: UUID, rank: Int?) {
         _appInfo = StateObject(wrappedValue: AppInfo(id: appId))
+        self.rank = rank
     }
 
     var body: some View {
-        HStack {
+        HStack(spacing: 9) {
             RandomImage(cornerRadius: 12)
             .frame(width: 62, height: 62)
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text(appInfo.name)
-                    .font(.subheadline)
-                Text(appInfo.subName)
-                    .font(.caption)
-                    .foregroundColor(Color(.lightGray))
+            HStack(spacing: 13) {
+                if let rank = self.rank {
+                    VStack(spacing: 6) {
+                        Text("\(rank)")
+                            .font(.subheadline)
+                        Text(" ")
+                            .font(.caption)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(appInfo.name)
+                        .font(.subheadline)
+                    Text(appInfo.subName)
+                        .font(.caption)
+                        .foregroundColor(Color(.lightGray))
+                }
             }
 
-            Spacer()
+            Spacer(minLength: 0)
 
             DownloadButton(hasPurchase: appInfo.hasInternalPurchase)
         }
@@ -40,6 +53,6 @@ struct SmallAppInfoView: View {
 
 struct SmallAppInfoView_Previews: PreviewProvider {
     static var previews: some View {
-        SmallAppInfoView(appId: UUID()).preferredColorScheme(.dark)
+        SmallAppInfoView(appId: UUID(), rank: nil).preferredColorScheme(.dark)
     }
 }

--- a/AppStoreClone/View/SmallAppInfoView.swift
+++ b/AppStoreClone/View/SmallAppInfoView.swift
@@ -8,6 +8,12 @@
 import SwiftUI
 
 struct SmallAppInfoView: View {
+    @StateObject private var appInfo: AppInfo
+
+    init(appId: UUID) {
+        _appInfo = StateObject(wrappedValue: AppInfo(id: appId))
+    }
+
     var body: some View {
         HStack {
             AsyncImage(url: URL(string: "https://source.unsplash.com/random")) { image in
@@ -19,23 +25,26 @@ struct SmallAppInfoView: View {
             .frame(width: 62, height: 62)
 
             VStack(alignment: .leading, spacing: 6) {
-                Text("리그 오브 레전드: 와일드 리프트")
+                Text(appInfo.name)
                     .font(.subheadline)
-                Text("5:5 MOBA 전투를 위한\n팀을 구성하세요")
+                Text(appInfo.subName)
                     .font(.caption)
                     .foregroundColor(Color(.lightGray))
             }
-            
+
             Spacer()
-            
-            DownloadButton(hasPurchase: false)
+
+            DownloadButton(hasPurchase: appInfo.hasInternalPurchase)
         }
         .frame(width: Constants.screenWidth - Constants.horizontalMargin * 2)
+        .task {
+            await appInfo.fetchInfo()
+        }
     }
 }
 
 struct SmallAppInfoView_Previews: PreviewProvider {
     static var previews: some View {
-        SmallAppInfoView().preferredColorScheme(.dark)
+        SmallAppInfoView(appId: UUID()).preferredColorScheme(.dark)
     }
 }

--- a/AppStoreClone/View/SmallAppInfoView.swift
+++ b/AppStoreClone/View/SmallAppInfoView.swift
@@ -16,12 +16,7 @@ struct SmallAppInfoView: View {
 
     var body: some View {
         HStack {
-            AsyncImage(url: URL(string: "https://source.unsplash.com/random")) { image in
-                image.resizable()
-            } placeholder: {
-                ProgressView()
-            }
-            .clipShape(RoundedRectangle(cornerRadius: 12))
+            RandomImage(cornerRadius: 12)
             .frame(width: 62, height: 62)
 
             VStack(alignment: .leading, spacing: 6) {

--- a/AppStoreClone/View/SmallAppInfoView.swift
+++ b/AppStoreClone/View/SmallAppInfoView.swift
@@ -9,40 +9,54 @@ import SwiftUI
 
 struct SmallAppInfoView: View {
     @StateObject private var appInfo: AppInfo
-    let rank: Int?
+    let index: Int
+    let ranked: Bool
 
-    init(appId: UUID, rank: Int?) {
+    init(appId: UUID, index: Int, ranked: Bool) {
         _appInfo = StateObject(wrappedValue: AppInfo(id: appId))
-        self.rank = rank
+        self.index = index
+        self.ranked = ranked
     }
 
     var body: some View {
-        HStack(spacing: 9) {
-            RandomImage(cornerRadius: 12)
-            .frame(width: 62, height: 62)
+        VStack {
+            HStack(spacing: 9) {
+                RandomImage(cornerRadius: 12)
+                .frame(width: 62, height: 62)
 
-            HStack(spacing: 13) {
-                if let rank = self.rank {
-                    VStack(spacing: 6) {
-                        Text("\(rank)")
+                HStack(spacing: 13) {
+                    if ranked {
+                        VStack(spacing: 6) {
+                            Text("\(index)")
+                                .font(.subheadline)
+                                .fontWeight(.semibold)
+                            Text(" ")
+                                .font(.caption)
+                        }
+                    }
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(appInfo.name)
                             .font(.subheadline)
-                        Text(" ")
+                        Text(appInfo.subName)
                             .font(.caption)
+                            .foregroundColor(Color(.lightGray))
                     }
                 }
 
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(appInfo.name)
-                        .font(.subheadline)
-                    Text(appInfo.subName)
-                        .font(.caption)
-                        .foregroundColor(Color(.lightGray))
-                }
+                Spacer(minLength: 0)
+
+                DownloadButton(hasPurchase: appInfo.hasInternalPurchase)
             }
 
-            Spacer(minLength: 0)
-
-            DownloadButton(hasPurchase: appInfo.hasInternalPurchase)
+            if !index.isMultiple(of: 3) {
+                HStack {
+                    Spacer()
+                    Rectangle()
+                        .foregroundColor(Color(.systemGray5))
+                        .frame(width: Constants.screenWidth - Constants.horizontalMargin * 2 - 71, height: 1)
+                }
+            }
         }
         .frame(width: Constants.screenWidth - Constants.horizontalMargin * 2)
         .task {
@@ -53,6 +67,6 @@ struct SmallAppInfoView: View {
 
 struct SmallAppInfoView_Previews: PreviewProvider {
     static var previews: some View {
-        SmallAppInfoView(appId: UUID(), rank: nil).preferredColorScheme(.dark)
+        SmallAppInfoView(appId: UUID(), index: 2, ranked: true).preferredColorScheme(.dark)
     }
 }

--- a/AppStoreClone/View/TopCardListView.swift
+++ b/AppStoreClone/View/TopCardListView.swift
@@ -33,7 +33,7 @@ struct TopCardListView: View {
             Divider()
                 .padding(.horizontal, Constants.horizontalMargin)
         }
-     }
+    }
 }
 
 struct TopCardListView_Previews: PreviewProvider {

--- a/AppStoreClone/View/TopCardView.swift
+++ b/AppStoreClone/View/TopCardView.swift
@@ -74,7 +74,7 @@ struct TopCardView: View {
                                 }
                                 .frame(width: 74, height: 29)
                             }
-                            if topCardAppInfo.isInternalPurchaseExists {
+                            if topCardAppInfo.hasInternalPurchase {
                                 Text("앱 내 구입")
                                     .font(.system(size: 9))
                                     .foregroundColor(.white)

--- a/AppStoreClone/View/TopCardView.swift
+++ b/AppStoreClone/View/TopCardView.swift
@@ -30,17 +30,7 @@ struct TopCardView: View {
                 Spacer()
             }
             ZStack {
-                AsyncImage(url: URL(string: "https://source.unsplash.com/random")) { image in
-                    image.resizable()
-                } placeholder: {
-                    VStack(spacing: 5) {
-                        ProgressView()
-                        Text("앱 정보 로드 중")
-                            .font(.caption)
-                            .foregroundColor(Color(.lightGray))
-                    }
-                }
-                .clipShape(RoundedRectangle(cornerRadius: 5))
+                RandomImage(cornerRadius: 5)
                 VStack {
                     Spacer()
                     HStack {

--- a/AppStoreClone/View/TopCardView.swift
+++ b/AppStoreClone/View/TopCardView.swift
@@ -61,25 +61,7 @@ struct TopCardView: View {
                         }
                         .padding(.bottom, 2)
                         Spacer()
-                        VStack(spacing: 5) {
-                            Button {
-                            } label: {
-                                ZStack {
-                                    RoundedRectangle(cornerRadius: 15)
-                                        .foregroundColor(.white.opacity(0.5))
-                                    Text("받기")
-                                        .font(.system(size: 14))
-                                        .fontWeight(.semibold)
-                                        .foregroundColor(.white)
-                                }
-                                .frame(width: 74, height: 29)
-                            }
-                            if topCardAppInfo.hasInternalPurchase {
-                                Text("앱 내 구입")
-                                    .font(.system(size: 9))
-                                    .foregroundColor(.white)
-                            }
-                        }
+                        DownloadButton(hasPurchase: topCardAppInfo.hasInternalPurchase)
                     }
                     .padding(.horizontal, 14)
                     .padding(.bottom, 9)

--- a/AppStoreClone/View/TopCardView.swift
+++ b/AppStoreClone/View/TopCardView.swift
@@ -51,7 +51,7 @@ struct TopCardView: View {
                         }
                         .padding(.bottom, 2)
                         Spacer()
-                        DownloadButton(hasPurchase: topCardAppInfo.hasInternalPurchase)
+                        DownloadButton(hasPurchase: topCardAppInfo.hasInternalPurchase, isBright: true)
                     }
                     .padding(.horizontal, 14)
                     .padding(.bottom, 9)


### PR DESCRIPTION
## 세부사항
* 받기 버튼, 앱 내 구입 문구를 DownloadButton으로 리펙토링
* AsyncImage를 RandomImage로 리펙토링
* SmallAppInfoView: 각 앱을 보여주는 역할
* SmallAppInfoColumnView: 앱을 3개씩 보여주는 column 역할
* SmallAppInfoListView: 여러 column이 paging 방식으로 보여지는 view

## 체크리스트
- [x] SwiftLint에서 error나 warning이 발생하지 않는 것을 확인하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋된 것을 확인하였습니다.

## 영상

https://user-images.githubusercontent.com/40821203/175782776-253ef14b-ff3e-45e5-a018-e5d5c76c35d8.mov

